### PR TITLE
Add utility method to XInclude a file

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -35,7 +35,7 @@ jobs:
           fi
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
-  build-and-deploy:
+  build-and-test:
     runs-on: ubuntu-latest
     needs: check_branch
     env:

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ plugins {
   id 'com.github.gmazzo.buildconfig' version "2.0.2"
 }
 
+sourceCompatibility=1.8
+targetCompatibility=1.8
+
 repositories {
   mavenLocal()
   mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx4096m
 
 basename=sinclude
 sincludeTitle=Saxon XInclude
-sincludeVersion=4.1.0
+sincludeVersion=4.2.0
 
-saxonVersion=11.3
+saxonVersion=11.4


### PR DESCRIPTION
Added `expandXIncludes(File input, File output)` that performs XInclude on the `input` and serializes the result to `output`.