### PR TITLE
Fix base URI when using the file convenience method

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx4096m
 
 basename=sinclude
 sincludeTitle=Saxon XInclude
-sincludeVersion=4.2.0
+sincludeVersion=4.2.1
 
 saxonVersion=11.4


### PR DESCRIPTION
The new convenience method performs XInclude on a file and serializes the result. This is always going to mean the new file has a different base URI. That messes up relative references. This patch simply says that if base URI fixup is being performed, and the root element doesn't already have an XML base attribute, add one that preserves the original file's location.
