### PR TITLE
Correct the defects in xml:lang processing

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,12 @@
 * Saxon XInclude Processor
+:PROPERTIES:
+:CUSTOM_ID: h-A2085245-5C37-47C0-A798-B9BA74A7E5DD
+:END:
 
 This is an [[http://www.w3.org/TR/xinclude][XInclude]] processor. It operates on the Saxon data model; it
 is not a streaming processor.
+
+At the Java level, it works like this:
 
 #+BEGIN_SRC java
 XdmNode document = … // You got a document from somewhere, right?
@@ -17,6 +22,9 @@ schemes could be added with relative ease, but that may be a bit
 aspirational.
 
 * Extension function
+:PROPERTIES:
+:CUSTOM_ID: h-9CC4637B-261F-45DB-8F6B-241DC0E722AF
+:END:
 
 You can use this XInclude implementation from XSLT as an extension
 function. Pass the command line option ~-init:com.nwalsh.xslt.Register~
@@ -48,7 +56,45 @@ map is a map from QName keys to values. Only two keys are recognized:
 value for each is “true”. You can omit the second argument entirely if
 you’re happy with those defaults.
 
+** Command line example
+:PROPERTIES:
+:CUSTOM_ID: h-38B19AEE-42B0-4828-A637-5E146C8334D7
+:END:
+
+You can use the ~xinclude.xsl~ file included in the distribution to
+expand the XIncludes in a document.
+
+The trickiest part, as usual with Java applications, is arranging for
+the correct classpath. You need to include the Saxon jar file, the
+SInclude jar file, and any other jars that are necessary for
+dependencies (for example, the XML Resolver jar files for Saxon 11+).
+
+If you have downloaded Saxon HE 11.5 and unzipped it into the
+directory ~saxon~, the following classpath will work:
+
+#+BEGIN_SRC
+export CLASSPATH=saxon/saxon-he-11.5.jar\
+:saxon/lib/xmlresolver-4.6.4.jar\
+:build/libs/sinclude-4.2.1.jar
+#+END_SRC
+
+On Windows, the syntax is different. And you may find it more
+convienent to run from a shell script. The actual transformation is:
+
+#+BEGIN_SRC
+java -cp $CLASSPATH net.sf.saxon.Transform \
+     -init:com.nwalsh.xslt.Register \
+     -xsl:src/test/resources/xinclude.xsl \
+     -s:input-document.xml -o:output-docuent.xml 
+#+END_SRC
+
+The =-init:= option will make sure that Saxon can find and use the
+extension function.
+
 * XPointer schemes
+:PROPERTIES:
+:CUSTOM_ID: h-38009E5E-7A17-49A7-9857-22D7201BB1D8
+:END:
 
 The standard [[https://www.w3.org/TR/xptr-xmlns/][xmlns()]] and [[https://www.w3.org/TR/xptr-element/][element()]] schemes are supported for XML parsing. An
 xpath() scheme is also supported. It evaluates an XPath expression against the document.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx4096m
 
 basename=sinclude
 sincludeTitle=Saxon XInclude
-sincludeVersion=4.2.1
+sincludeVersion=5.0.0
 
-saxonVersion=11.4
+saxonVersion=11.5

--- a/src/main/java/com/nwalsh/sinclude/schemes/ElementScheme.java
+++ b/src/main/java/com/nwalsh/sinclude/schemes/ElementScheme.java
@@ -14,11 +14,13 @@ public class ElementScheme extends XPathScheme {
     private String fragid = null;
 
     @Override
-    public ElementScheme newInstance(String fdata, XInclude xinclude) {
+    public ElementScheme newInstance(String fdata, XInclude xinclude, String contextLanguage, String contextBaseURI) {
         ElementScheme scheme = new ElementScheme();
         scheme.xinclude = xinclude;
         scheme.fragid = fdata;
         scheme.xpath = toXPath(fdata);
+        scheme.contextLanguage = contextLanguage;
+        scheme.contextBaseURI = contextBaseURI;
         return scheme;
     }
 

--- a/src/main/java/com/nwalsh/sinclude/schemes/XPathScheme.java
+++ b/src/main/java/com/nwalsh/sinclude/schemes/XPathScheme.java
@@ -21,10 +21,12 @@ public class XPathScheme extends AbstractXmlScheme implements XmlScheme {
     protected String xpath = null;
 
     @Override
-    public XPathScheme newInstance(String fdata, XInclude xinclude) {
+    public XPathScheme newInstance(String fdata, XInclude xinclude, String contextLanguage, String contextBaseURI) {
         XPathScheme scheme = new XPathScheme();
         scheme.xpath = fdata;
         scheme.xinclude = xinclude;
+        scheme.contextLanguage = contextLanguage;
+        scheme.contextBaseURI = contextBaseURI;
         return scheme;
     }
 

--- a/src/main/java/com/nwalsh/sinclude/schemes/XmlnsScheme.java
+++ b/src/main/java/com/nwalsh/sinclude/schemes/XmlnsScheme.java
@@ -17,7 +17,7 @@ public class XmlnsScheme implements XmlScheme {
     private XmlnsData data = null;
 
     @Override
-    public XmlnsScheme newInstance(String fdata, XInclude xinclude) {
+    public XmlnsScheme newInstance(String fdata, XInclude xinclude, String contextLanguage, String contexBaseURI) {
         XmlnsData data = null;
         Matcher matcher = nsRE.matcher(fdata);
         if (matcher.find()) {

--- a/src/main/java/com/nwalsh/sinclude/utils/NodeUtils.java
+++ b/src/main/java/com/nwalsh/sinclude/utils/NodeUtils.java
@@ -1,0 +1,23 @@
+package com.nwalsh.sinclude.utils;
+
+import net.sf.saxon.s9api.QName;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XdmNodeKind;
+
+import javax.xml.XMLConstants;
+
+public class NodeUtils {
+    public static final QName xml_id = new QName("xml", XMLConstants.XML_NS_URI, "id");
+    public static final QName xml_lang = new QName("xml", XMLConstants.XML_NS_URI, "lang");
+    public static final QName xml_base = new QName("xml", XMLConstants.XML_NS_URI, "base");
+
+    public static String getLang(XdmNode node) {
+        String lang = null;
+        while (lang == null && node.getNodeKind() == XdmNodeKind.ELEMENT) {
+            lang = node.getAttributeValue(xml_lang);
+            node = node.getParent();
+        }
+        return lang;
+    }
+}
+

--- a/src/main/java/com/nwalsh/sinclude/xpointer/FragmentIdParser.java
+++ b/src/main/java/com/nwalsh/sinclude/xpointer/FragmentIdParser.java
@@ -1,5 +1,9 @@
 package com.nwalsh.sinclude.xpointer;
 
+import net.sf.saxon.s9api.QName;
+
 public interface FragmentIdParser {
+    public void setProperty(QName property, String value);
+    public String getProperty(QName property);
     public Scheme[] parseFragmentIdentifier(ParseType parseType, String fragid);
 }

--- a/src/main/java/com/nwalsh/sinclude/xpointer/XmlScheme.java
+++ b/src/main/java/com/nwalsh/sinclude/xpointer/XmlScheme.java
@@ -3,6 +3,6 @@ package com.nwalsh.sinclude.xpointer;
 import com.nwalsh.sinclude.XInclude;
 
 public interface XmlScheme extends Scheme {
-    public Scheme newInstance(String fragid, XInclude xinclude);
+    public Scheme newInstance(String fragid, XInclude xinclude, String contextLanguage, String contextBaseURI);
 }
 

--- a/src/test/java/com/nwalsh/sinclude/LangFixupTest.java
+++ b/src/test/java/com/nwalsh/sinclude/LangFixupTest.java
@@ -1,0 +1,51 @@
+package com.nwalsh.sinclude;
+
+import com.nwalsh.sinclude.exceptions.XIncludeIntegrityCheckException;
+import com.nwalsh.sinclude.exceptions.XIncludeLoopException;
+import com.nwalsh.sinclude.exceptions.XIncludeNoFragmentException;
+import junit.framework.TestCase;
+import net.sf.saxon.s9api.DocumentBuilder;
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.trans.XPathException;
+import org.junit.Assert;
+import org.xml.sax.InputSource;
+
+import javax.xml.transform.sax.SAXSource;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+public class LangFixupTest extends TestCase {
+    private Processor processor = new Processor(false);
+
+    public void testLangFixup() {
+        try {
+            XInclude include = new XInclude();
+            include.setFixupXmlLang(true);
+            include.setFixupXmlBase(false);
+            DocumentBuilder builder = processor.newDocumentBuilder();
+            XdmNode doc = builder.build(new File("src/test/resources/langfixup.xml"));
+            XdmNode resolved = include.expandXIncludes(doc);
+            String aug = resolved.toString();
+
+            Assert.assertTrue(aug.contains("<p xml:lang=\"en\">English")
+                    || aug.contains("<p xml:lang='en'>English"));
+            Assert.assertTrue(aug.contains("<p xml:lang=\"de\">Deutsch")
+                    || aug.contains("<p xml:lang='de'>Deutsch"));
+            Assert.assertTrue(aug.contains("<p xml:lang=\"\">Unspecified")
+                    || aug.contains("<p xml:lang=''>Unspecified"));
+
+            Assert.assertTrue(aug.contains("<chap xml:lang=\"en\">")
+                    || aug.contains("<chap xml:lang='en'>"));
+            Assert.assertTrue(aug.contains("<chap xml:lang=\"de\">")
+                    || aug.contains("<chap xml:lang='de'>"));
+            Assert.assertTrue(aug.contains("<chap xml:lang=\"\">")
+                    || aug.contains("<chap xml:lang=''>"));
+
+        } catch (SaxonApiException|XPathException ex) {
+            fail();
+        }
+    }
+}

--- a/src/test/resources/lang-de.xml
+++ b/src/test/resources/lang-de.xml
@@ -1,0 +1,1 @@
+<chap xml:lang="de"><p>Deutsch.</p></chap>

--- a/src/test/resources/lang-en.xml
+++ b/src/test/resources/lang-en.xml
@@ -1,0 +1,1 @@
+<chap xml:lang="en"><p>English.</p></chap>

--- a/src/test/resources/lang-xx.xml
+++ b/src/test/resources/lang-xx.xml
@@ -1,0 +1,1 @@
+<chap><p>Unspecified.</p></chap>

--- a/src/test/resources/langfixup.xml
+++ b/src/test/resources/langfixup.xml
@@ -1,0 +1,11 @@
+<doc xml:lang="en" xmlns:xi='http://www.w3.org/2001/XInclude'>
+  <chap>
+    <p>This document is in English.</p>
+    <xi:include href="lang-en.xml" xpointer="element(/1/1)"/>
+    <xi:include href="lang-de.xml" xpointer="element(/1/1)"/>
+    <xi:include href="lang-xx.xml" xpointer="element(/1/1)"/>
+  </chap>
+  <xi:include href="lang-en.xml"/>
+  <xi:include href="lang-de.xml"/>
+  <xi:include href="lang-xx.xml"/>
+</doc>

--- a/src/test/resources/xinclude.xsl
+++ b/src/test/resources/xinclude.xsl
@@ -3,27 +3,14 @@
                 xmlns:ext="http://nwalsh.com/xslt"
                 xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                exclude-result-prefixes="ext xi xs"
+                exclude-result-prefixes="#all"
                 version="3.0">
 
-<xsl:template match="/">
-  <xsl:document>
-    <xsl:apply-templates/>
-  </xsl:document>
-</xsl:template>
-
-<xsl:template match="element()">
-  <xsl:copy>
-    <xsl:apply-templates select="@*,node()"/>
-  </xsl:copy>
-</xsl:template>
+<xsl:output method="xml" encoding="utf-8" indent="no"/>
+<xsl:mode on-no-match="shallow-copy"/>
 
 <xsl:template match="xi:include">
   <xsl:sequence select="ext:xinclude(.)"/>
-</xsl:template>
-
-<xsl:template match="attribute()|text()|comment()|processing-instruction()">
-  <xsl:copy/>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
If a document (or node) which has no declared `xml:lang` is inserted into a document that *does* have a declared language, make sure that `xml:lang=""` is added to the inserted elements.

Fix #8 

Updated the README.org file to document the Saxon command line necessary to perform XInclude.

Fix #2 

