### PR TITLE
Allow string keys in the extension function map

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 basename=sinclude
 sincludeTitle=Saxon XInclude
-sincludeVersion=5.2.1
+sincludeVersion=5.2.2
 
 saxonVersion=11.5

--- a/src/main/java/com/nwalsh/xslt/XIncludeFunction.java
+++ b/src/main/java/com/nwalsh/xslt/XIncludeFunction.java
@@ -83,12 +83,7 @@ public class XIncludeFunction extends ExtensionFunctionDefinition {
 
             boolean fixupBase = getBooleanOption(_fixup_xml_base, true);
             boolean fixupLang = getBooleanOption(_fixup_xml_lang, true);
-
-            boolean defaultTrimText = false;
-            boolean trimText = defaultTrimText;
-            if (getBooleanOption(_trim_text, false)) {
-                trimText = true;
-            }
+            boolean trimText = getBooleanOption(_trim_text, false);
 
             XdmNode doc = new XdmNode(source);
             XInclude xinclude = new XInclude();
@@ -129,7 +124,20 @@ public class XIncludeFunction extends ExtensionFunctionDefinition {
             AtomicValue next = aiter.next();
             while (next != null) {
                 final QName key;
-                if (next.getItemType() == BuiltInAtomicType.QNAME) {
+                if (next.getItemType() == BuiltInAtomicType.STRING) {
+                    String keyname = next.getStringValue();
+                    if (keyname.contains(":")) {
+                        throw new IllegalArgumentException("Option map string keys must not contain a colon");
+                    }
+                    if (keyname.equals(_fixup_xml_base.getLocalName())
+                        || keyname.equals(_fixup_xml_lang.getLocalName())
+                        || keyname.equals(_trim_text.getLocalName())) {
+                        key = new QName("", keyname);
+                    } else {
+                        throw new IllegalArgumentException("Unrecognized option map string key: " + keyname);
+                    }
+
+                } else if (next.getItemType() == BuiltInAtomicType.QNAME) {
                     key = NamespaceUtils.qName((QNameValue) next);
                 } else {
                     throw new IllegalArgumentException("Option map keys must be QNames");

--- a/src/test/java/com/nwalsh/xslt/ExtFunctionTest.java
+++ b/src/test/java/com/nwalsh/xslt/ExtFunctionTest.java
@@ -152,35 +152,4 @@ public class ExtFunctionTest extends TestCase {
             throw new RuntimeException("Value returned where node was expected");
         }
     }
-
-    public void foo() {
-        String stylesheet = "";
-        stylesheet += "<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform'\n";
-        stylesheet += "                xmlns:ext='http://nwalsh.com/xslt'\n";
-        stylesheet += "                version='3.0'>\n\n";
-        stylesheet += "<xsl:output method='text' encoding='utf-8'/>\n\n";
-        stylesheet += "<xsl:template match='/' name='main'>\n";
-        stylesheet += "  <xsl:value-of select=\"'hello world'\"/>\n";
-        stylesheet += "</xsl:template>\n\n";
-        stylesheet += "</xsl:stylesheet>\n";
-
-        ByteArrayInputStream bais = new ByteArrayInputStream(
-                stylesheet.getBytes(StandardCharsets.UTF_8));
-
-        try {
-            RawDestination result = new RawDestination();
-            XsltCompiler compiler = processor.newXsltCompiler();
-            XsltExecutable exec = compiler.compile(new SAXSource(new InputSource(bais)));
-            XsltTransformer transformer = exec.load();
-            transformer.setDestination(result);
-            transformer.setInitialTemplate(new QName("", "main"));
-            transformer.transform();
-            XdmValue value = result.getXdmValue();
-            System.err.println(value);
-        } catch (SaxonApiException sae) {
-            sae.printStackTrace();
-            TestCase.fail();
-        }
-    }
-
 }


### PR DESCRIPTION
In the course of writing documentation, I decided to relax the constraints on option map keys and allow the option names to be passed in as strings. This is much simpler for users. Namespace keys are still allowed.

(It's arguable that `trim-text` should be required to be in a namespace, but I'm not.)