### PR TITLE
Make the text-trim feature consistent with the trim option on search=

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 basename=sinclude
 sincludeTitle=Saxon XInclude
-sincludeVersion=5.2.2
+sincludeVersion=5.2.3
 
 saxonVersion=11.5

--- a/src/main/java/com/nwalsh/sinclude/XInclude.java
+++ b/src/main/java/com/nwalsh/sinclude/XInclude.java
@@ -447,13 +447,26 @@ public class XInclude {
             // spaces off each line. All trailing spaces are stripped, the number of leading
             // spaces is determined by the number of spaces on the first line.
             if (getTrimText() && parse == ParseType.TEXTPARSE) {
-                String text = doc.getStringValue();
-                String[] lines = text.split("\n", -1); // -1 == include empty trailing strings
+                String[] lines = doc.getStringValue().split("\n", -1); // -1 == include empty trailing strings
+
                 if (lines.length > 0) {
-                    int trimleading = 0;
-                    while (trimleading < lines[0].length() && lines[0].charAt(trimleading) == ' ') {
-                        trimleading++;
+                    int trimleading = -1;
+                    for (String line : lines) {
+                        // (Effectively) blank lines don't count
+                        if (!"".equals(line.trim())) {
+                            int leading = 0;
+                            while (leading < line.length() && line.charAt(leading) == ' ') {
+                                leading++;
+                            }
+                            if (trimleading < 0 || leading < trimleading) {
+                                trimleading = leading;
+                            }
+                            if (trimleading == 0) {
+                                break;
+                            }
+                        }
                     }
+
                     XdmDestination destination = ReceiverUtils.makeDestination(doc);
                     Receiver receiver = ReceiverUtils.makeReceiver(doc, destination);
                     for (int pos = 0; pos < lines.length; pos++) {

--- a/src/test/java/com/nwalsh/sinclude/FakeDocumentResolver.java
+++ b/src/test/java/com/nwalsh/sinclude/FakeDocumentResolver.java
@@ -182,7 +182,7 @@ public class FakeDocumentResolver implements DocumentResolver {
         textMap.put("one.txt", "This is line one.\n");
         textMap.put("two.txt", "\n\n\n\n\n\n\n\n\nThis is line 10.\n\n\n\n\nThis is line 15.");
         textMap.put("three.xml", "<doc>Document three.</doc>");
-        textMap.put("four.txt", "    Four leading blanks\n   {\n      Three leading blanks\n  }\n       Four leading blanks\nNo leading blanks");
+        textMap.put("four.txt", "    Four leading blanks\n   {\n   Three leading blanks\n   }\n    Four leading blanks\n  Two leading blanks");
     }
 
     private static Map<String, String> expandedMap = null;
@@ -318,7 +318,7 @@ public class FakeDocumentResolver implements DocumentResolver {
                 "</doc>\n");
         expandedMap.put("selfrefloop.xml", "<doc/>");
         expandedMap.put("trimtext.xml", "<doc xmlns:xi='http://www.w3.org/2001/XInclude'>\n" +
-                "{\n   Three leading blanks\n}\n    Four leading blanks\nNo leading blanks\n\n" +
+                " {\n Three leading blanks\n }\n  Four leading blanks\nTwo leading blanks\n\n" +
                 "</doc>\n");
 
     }


### PR DESCRIPTION
Sigh. It's been a bit of a careless day. In the course of documenting SInclude, I discovered that the choice I made for the `trim-text` feature (regarding how many spaces to trim) and the choice already made for the `trim` option on the `search=` text scheme were different.

That seems confusing and there's no legacy for the `trim-text` feature, so I'm quickly fixing it to be the same as the `trim` option on the `search=` scheme.